### PR TITLE
Redo the handling of the re-execution step

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -19,11 +19,11 @@
     * [x] Simulation relation for `G_s'` (done with minor admits)
     * [x] Full admitless proof of the simulation relation for `G_s'`
     * [x] Provide a universal rhb nesting for source graph
-    * [ ] Proof of the step (done with medium admits) -- new estimate N/A (minimum: proof with minor admits)
+    * [x] Proof of the step (done with medium admits) -- new estimate N/A (minimum: proof with minor admits)
         - [x] Deploy the fix for the `StableUncommittedReads`, including the fixes of all proofs reasoning about it [commit](weakmemory/xmm/f9742bc1094d4b2bdffec5835afb889f9224afc1)
         - [x] Prove the inclusion of srf into the thrdle relation [commit](weakmemory/xmm/148c9e30a13db554e305380252be3949e712169b)
         - [x] Prove the inclusion of other `rf` edges (merge into `main` past this step)
-        - [ ] Prove the well-formedness of the starting configuration
+        - [x] Prove the well-formedness of the starting configuration
         - [x] Prove all other conditions of the `re-execute` step
             - [x] Commit-embeded up-to rpo [commit](https://github.com/weakmemory/xmm/commit/259a1698508bc26ffa74edc193c5dcff92a16d5b)
             - [x] Add the new constraints and patch all lemmas up-to-rexec [commit1](https://github.com/weakmemory/xmm/commit/aaa3968807c1239e1496273ae67e82a1d518d401), [commit2](https://github.com/weakmemory/xmm/commit/e739362f70188d3259b694b08a877ce58a7320f8)
@@ -42,3 +42,28 @@
 - [ ] [@InnocentusLime](https://www.github.com/InnocentusLime) Document constraints
     - The main foundational constaints should be converted into `Hypothesis` declarations
     - Each hypothesis should be followed by a comment
+
+## Admits in the re-execution step
+
+The proof for the re-execution step itself has been successfully `Qed`. The only thing left to do is to proof the admitted statements:
+
+- [ ] dtrmt_in_cmt (dtrmt_s ⊆ cmt_s)
+- [ ] cmt_in_Es (cmt_s ⊆ E_s')
+- [ ] dtrmt_in_Es (dtrmt_s ⊆ E_s)
+- [ ] rex_dtrmt_init (is_init ⊆ dtrmt_s)
+- [ ] Infer from `forall e : actid,
+E_t' e -> tid e = tid b_t -> cmt_t e` that b_t is determined (aka, if all events in a thread are comitted => then all events are determined).
+- [ ] `MAP : mapper ↑ vf_rhb_t' ⨾ same_tid ⨾ mapper ↑ ⦗E_t' \₁ cmt_t⦘ ⊆ mapper ↑ (vf_rhb_t' ⨾ same_tid ⨾ ⦗E_t' \₁ cmt_t⦘)` -- some algebraic juggling of mapper
+- [ ] The final steps of `rsr_rex_vf` (they are obvious)
+- [ ] Cases in `reexec_threads_s`
+- [ ] `imm_sb_d_s` -- the lemma about po-max of dtmtr_s
+- [ ] po-closure of `dtrmt_s` in `G_s`
+- [ ] Its corollary -- the same thing but about `G_s'`
+- [ ] Proof that `G_s` restricted by `dtrmt_s` is a prefix of `G_s'`
+- [ ] `commit_embedded` predicate
+- [ ] Various relations hacks in `rsr_rex_crfc_vf`
+    - [ ] `arewrite` 1
+    - [ ] `arewrite` 2
+    - [ ] `arewrite` 3
+    - [ ] "determined event from target reads from a comitted event"
+- [ ] In `rsr_rex_crfc_helper` show that if `b_t` is determined in target, but `a_t` is absent from `G_t'` -- then all events before `a_s'` (extra a) are actually determined

--- a/src/lib/Srf.v
+++ b/src/lib/Srf.v
@@ -343,6 +343,14 @@ Proof using.
   now rewrite sbvf_as_rhb.
 Qed.
 
+Lemma srf_rhb_vf_rhb_sb :
+  srf_rhb ⊆ vf_rhb ⨾ sb.
+Proof using.
+  unfold srf_rhb.
+  remember (co ⨾ vf_rhb ⨾ sb) as minus.
+  basic_solver.
+Qed.
+
 Lemma from_srf dtrmt
     (WF : Wf G)
     (SUBE : dtrmt ⊆₁ E)

--- a/src/lib/Srf.v
+++ b/src/lib/Srf.v
@@ -351,6 +351,26 @@ Proof using.
   basic_solver.
 Qed.
 
+Lemma wf_vfrhbE
+    (WF : Wf G) :
+  vf_rhb ≡ ⦗E⦘ ⨾ vf_rhb ⨾ ⦗E⦘.
+Proof using.
+  apply dom_helper_3.
+  unfold vf_rhb.
+  rewrite (wf_rfE WF), (wf_rhbE WF).
+  basic_solver.
+Qed.
+
+Lemma vf_rhb_to_init
+    (WF : Wf G) :
+  vf_rhb ⨾ ⦗is_init⦘ ⊆ ⦗is_init⦘.
+Proof using.
+  unfold vf_rhb.
+  rewrite (no_rf_to_init WF).
+  rewrite (no_rhb_to_init WF).
+  basic_solver.
+Qed.
+
 Lemma from_srf dtrmt
     (WF : Wf G)
     (SUBE : dtrmt ⊆₁ E)

--- a/src/reordering/ReorderingNewGraph.v
+++ b/src/reordering/ReorderingNewGraph.v
@@ -817,6 +817,68 @@ Proof using INV.
   reflexivity.
 Qed.
 
+Lemma imm_G_s_sb :
+  sb_s'' ≡
+    mapper ↑ swap_rel sb_t (eq b_t ∩₁ E_t) (eq a_t ∩₁ E_t).
+Proof using INV.
+  assert (NSBAB : ~ext_sb a_t b_t).
+  { intro FALSO.
+    now eapply ext_sb_irr, ext_sb_trans, (rsr_at_bt_sb INV). }
+  assert (NEQ : a_t <> b_t) by apply INV.
+  unfold sb at 1. simpl.
+  rewrite mapped_swap_rel.
+  rewrite set_union_minus
+      with (s := E_t) (s' := eq b_t ∩₁ E_t ∪₁ eq a_t ∩₁ E_t)
+        at 1 2
+        by basic_solver.
+  rewrite !set_collect_union.
+  arewrite (
+    E_t \₁ (eq b_t ∩₁ E_t ∪₁ eq a_t ∩₁ E_t) ≡₁
+      (E_t \₁ eq b_t) \₁ eq a_t
+  ).
+  { rewrite <- set_minus_minus_l.
+    rewrite !set_minus_inter_r.
+    rewrite set_minusK, set_union_empty_r.
+    arewrite ((E_t \₁ eq b_t) \₁ E_t ≡₁ ∅).
+    { basic_solver. }
+    now rewrite set_union_empty_r. }
+  rewrite !id_union.
+  rewrite !seq_union_l, !seq_union_r.
+  rewrite <- !unionA.
+  arewrite_false (
+    ⦗mapper ↑₁ (eq b_t ∩₁ E_t)⦘ ⨾
+      ext_sb ⨾
+        ⦗mapper ↑₁ (eq b_t ∩₁ E_t)⦘
+  ).
+  { unfolder. ins. desf.
+    eapply ext_sb_irr; eauto. }
+  arewrite_false (
+    ⦗mapper ↑₁ (eq a_t ∩₁ E_t)⦘ ⨾
+      ext_sb ⨾
+        ⦗mapper ↑₁ (eq a_t ∩₁ E_t)⦘
+  ).
+  { unfolder. ins. desf.
+    eapply ext_sb_irr; eauto. }
+  arewrite_false (
+    ⦗mapper ↑₁ (eq b_t ∩₁ E_t)⦘ ⨾
+      ext_sb ⨾
+        ⦗mapper ↑₁ (eq a_t ∩₁ E_t)⦘
+  ).
+  { unfolder.
+    intros x y
+      ((x' & (XEQ & XIN) & XEQ') &
+       SB &
+       (y' & (YEQ & YIN) & YEQ')).
+    subst x' y'. apply NSBAB.
+    rewrite (rsr_mapper_at NEQ), (rsr_mapper_bt NEQ) in *.
+    now subst x y. }
+  rewrite !union_false_r.
+  rewrite rsr_setE_iff
+     with (s := (E_t \₁ eq b_t) \₁ eq a_t)
+       by (auto || (right; unfold not; basic_solver)).
+  reflexivity.
+Qed.
+
 Lemma new_G_s_sb :
   sb_s ≡
     mapper ↑ swap_rel sb_t (eq b_t ∩₁ E_t) (eq a_t ∩₁ E_t) ∪

--- a/src/reordering/ReorderingReexec.v
+++ b/src/reordering/ReorderingReexec.v
@@ -990,6 +990,12 @@ Lemma sb_d_closed :
 Proof using INV INV' STEP LVAL NLOC ARW ARLX.
 Admitted.
 
+Lemma sb_d_closed' :
+  sb_s' ⨾ ⦗dtrmt_s⦘ ⊆
+    ⦗dtrmt_s⦘ ⨾ sb_s' ⨾ ⦗dtrmt_s⦘.
+Proof using INV INV' STEP LVAL NLOC ARW ARLX.
+Admitted.
+
 Lemma rex_pfx :
   SubToFullExec.prefix (WCore.X_start X_s dtrmt_s) X_s'.
 Proof using INV INV' STEP LVAL NLOC ARW ARLX.
@@ -1083,6 +1089,72 @@ Proof using SIMREL INV INV' LVAL STEP NLOC ARW ARLX RCFAT.
   rewrite union_false_l. basic_solver.
 Qed.
 
+Lemma rsr_hb_in_d :
+  hb_s' ⨾ ⦗dtrmt_s⦘ ⊆
+    ⦗dtrmt_s⦘ ⨾ hb_s' ⨾ ⦗dtrmt_s⦘.
+Proof using SIMREL INV INV' LVAL STEP NLOC ARW ARLX RCFAT.
+  enough (DOM :
+    dom_rel (hb_s' ⨾ ⦗dtrmt_s⦘) ⊆₁ dtrmt_s
+  ).
+  { unfolder. intros x y (HB & DX). splits; auto.
+    apply DOM. exists y. basic_solver. }
+  unfold hb.
+  rewrite clos_trans_doma_r_strong,
+          ct_begin; [clear; basic_solver |].
+  rewrite seq_union_l, rsr_sw_in_d, sb_d_closed'.
+  apply union_doma.
+  all: basic_solver.
+Qed.
+
+Lemma rsr_rex_crfc_vf :
+  dom_rel (vf_s' ⨾ ⦗dtrmt_s⦘ ⨾ sb_s' ⨾ ⦗A_s'⦘) ⊆₁ cmt_s.
+Proof using SIMREL INV INV' LVAL STEP NLOC ARW ARLX RCFAT.
+  unfold vf.
+  rewrite !seqA.
+  arewrite (
+    ⦗dtrmt_s⦘ ⨾ sb_s' ⨾ ⦗A_s'⦘ ⊆
+      ⦗dtrmt_s \₁ (eq a_t ∪₁ A_s')⦘ ⨾ sb_s' ⨾ ⦗A_s'⦘
+  ).
+  { admit. }
+  arewrite (
+    hb_s'^? ⨾ ⦗dtrmt_s \₁ (eq a_t ∪₁ A_s')⦘ ⨾ sb_s' ⨾ ⦗A_s'⦘ ⊆
+      ⦗dtrmt_s \₁ (eq a_t ∪₁ A_s')⦘ ⨾ hb_s'^? ⨾ sb_s' ⨾ ⦗A_s'⦘
+  ).
+  { rewrite crE, !seq_union_l, !seq_union_r.
+    apply union_mori; [basic_solver |].
+    (* apply rsr_hb_in_d. *) admit. }
+  arewrite (
+    rf_s'^? ⨾ ⦗dtrmt_s \₁ (eq a_t ∪₁ A_s')⦘ ⊆
+    (mapper ↑ rf_t')^? ⨾ ⦗dtrmt_s \₁ (eq a_t ∪₁ A_s')⦘
+  ).
+  { rewrite !crE, !seq_union_l.
+    apply union_mori; [reflexivity |].
+    rewrite (rsr_rf reexec_simrel), seq_union_l.
+    rewrite seqA. seq_rewrite <- id_inter.
+    arewrite (
+      A_s' ∩₁ R_s' ∩₁
+        (dtrmt_s \₁ (eq a_t ∪₁ A_s')) ⊆₁ ∅
+    ); [clear; basic_solver|].
+    now rewrite eqv_empty, seq_false_r, union_false_r. }
+  arewrite (
+    dtrmt_s \₁ (eq a_t ∪₁ A_s') ⊆₁
+      mapper ↑₁ dtrmt_t
+  ).
+  { admit. }
+  arewrite (
+    (mapper ↑ rf_t')^? ⨾ ⦗mapper ↑₁ dtrmt_t⦘ ⊆
+      ⦗cmt_s⦘ ⨾ (mapper ↑ rf_t')^?
+  ).
+  { rewrite crE, !seq_union_l, !seq_union_r.
+    apply union_mori.
+    { rewrite seq_id_l, <- id_inter. apply eqv_rel_mori.
+      apply set_subset_inter_r. split; auto with hahn.
+      rewrite (WCore.dtrmt_cmt STEP).
+      unfold cmt_s. basic_solver. }
+    admit. }
+  clear. basic_solver.
+Admitted.
+
 Lemma rsr_rex_crfc_helper
     (DB : dtrmt_t b_t)
     (NINA : ~E_t' a_t) :
@@ -1113,6 +1185,13 @@ Proof using INV INV' LVAL STEP NLOC ARW ARLX RCFAT.
   all: try now apply WF.
   { apply (rsr_fin_s INV' reexec_simrel). }
   exists w. splits; auto.
+  destruct SRF as ((r & ((VFSB & _) & ISR')) & _).
+  red in ISR'. destruct ISR' as (REQ & _). subst r.
+  destruct VFSB as (e & VF & SB).
+  assert (ED : dtrmt_s e).
+  { admit. }
+  apply rsr_rex_crfc_vf, set_subset_single_l.
+  rewrite extra_a_some; auto. basic_solver 11.
 Admitted.
 
 Lemma rsr_rex_crfc :

--- a/src/reordering/ReorderingReexec.v
+++ b/src/reordering/ReorderingReexec.v
@@ -719,7 +719,10 @@ Proof using INV' STEP.
       apply (rsr_mapper_inj NEQ).
       all: try red; auto. }
     unfold exa_d in EXA. desf.
-    admit. }
+    unfold a_s in *.
+    enough (E_t' a_t) by desf.
+    enough (e = a_t) by congruence.
+    eapply rsr_mapper_inv_bt; eauto. }
   assert (FOR' :
     forall e, ~(~cmt_t e /\ tid e = tid b_t /\ E_t' e)
   ).
@@ -854,6 +857,7 @@ Proof using INV' STEP LVAL.
   ).
   { apply thrdle_with_rhb; try now apply STEP.
     all: apply INV'. }
+  admit.
 Admitted.
 
 Lemma reexec_threads_s :
@@ -902,7 +906,7 @@ Qed.
 
 Lemma reexec_acts_s :
   E_s ≡₁ dtrmt_s ∪₁ E_s ∩₁ tid ↓₁ WCore.reexec_thread X_s' dtrmt_s.
-Proof using INV INV' SIMREL RCFAT.
+Proof using INV INV' SIMREL RCFAT STEP.
   clear - INV INV' STEP SIMREL RCFAT.
   assert (NEQ : a_t <> b_t) by apply INV.
   assert (TID : tid a_t = tid b_t) by apply INV.
@@ -925,12 +929,12 @@ Proof using INV INV' SIMREL RCFAT.
       extra_d
     )
   ).
-  { admit. }
+  { clear. basic_solver. }
   arewrite (
     A_s \₁ dtrmt_s ⊆₁
       A_s \₁ exa_d
   ).
-  { admit. }
+  { clear. unfold dtrmt_s. basic_solver. }
   apply set_subset_union_l. split.
   { unfold dtrmt_s.
     transitivity (
@@ -946,7 +950,9 @@ Proof using INV INV' SIMREL RCFAT.
       all: unfold flip; auto with hahn.
       rewrite <- reexec_thread_mapper.
       apply set_collect_mori; auto.
-      admit. }
+      rewrite (WCore.rexec_acts STEP), set_minus_union_l.
+      rewrite set_minusK, set_union_empty_l.
+      clear. basic_solver. }
     unfold extra_b; desf; [| basic_solver].
     rewrite set_collect_eq, rsr_mapper_bt; auto.
     unfold WCore.reexec_thread.
@@ -967,7 +973,7 @@ Proof using INV INV' SIMREL RCFAT.
   { intro FALSO. enough (E_t a_t) by tauto.
     now apply (rexec_dtrmt_in_start STEP). }
   unfold WCore.reexec_thread. basic_solver.
-Admitted.
+Qed.
 
 Lemma imm_sb_d_s :
   ⦗dtrmt_s⦘ ⨾ immediate (nin_sb G_s') ⨾ ⦗cmt_s⦘ ⊆
@@ -1029,8 +1035,11 @@ Proof using INV INV' STEP LVAL NLOC ARW ARLX.
   assert (NEQ' : b_t <> a_t) by now symmetry.
   constructor; ins.
   { admit. }
-  { admit. }
-  { admit. }
+  { apply rex_pfx. }
+  { eapply eq_dom_mori; try now apply rex_pfx.
+    all: ins.
+    unfold flip. rewrite set_inter_absorb_r; [basic_solver |].
+    auto with xmm. }
   { now rewrite (prf_rf rex_pfx), restr_restr, set_inter_absorb_l. }
   { now rewrite (prf_co rex_pfx), restr_restr, set_inter_absorb_l. }
   { now rewrite (prf_rmw rex_pfx), restr_restr, set_inter_absorb_l. }
@@ -1184,7 +1193,8 @@ Lemma rsr_rex_crfc_helper
 Proof using INV INV' LVAL STEP NLOC ARW ARLX RCFAT.
   assert (WF : Wf G_s').
   { apply (new_G_s_wf INV' LVAL). }
-  assert (BIN : E_t' b_t) by admit.
+  assert (BIN : E_t' b_t).
+  { now apply (rexec_dtrmt_in_fin STEP). }
   assert (BCMT : cmt_s b_t).
   { unfold cmt_s. right. unfold exa_d; desf.
     tauto. }

--- a/src/reordering/ReorderingReexec.v
+++ b/src/reordering/ReorderingReexec.v
@@ -875,115 +875,30 @@ Proof using INV INV'.
   all: unfolder; rewrite <- TID; auto.
 Qed.
 
-Lemma reexec_acts_s_helper
-    (GREEXEC : WCore.reexec_gen X_t X_t' f_t dtrmt_t cmt_t thrdle) :
-  A_s ⊆₁ tid ↓₁ WCore.reexec_thread X_t' dtrmt_t ∪₁
-            tid ↓₁ (tid ↑₁ A_s').
-Proof using INV INV'.
-  clear - INV INV' GREEXEC.
-  assert (TEQ : tid a_t = tid b_t) by apply INV.
-  unfold extra_a at 1; desf.
-  assert (NDA : ~ dtrmt_t a_t).
-  { intro FALSO. enough (E_t a_t) by desf.
-    eapply rexec_dtrmt_in_start; eauto. }
-  destruct classic with (dtrmt_t b_t) as [DB|NDB].
-  { unfold extra_a; desf; [basic_solver |].
-    assert (INB : E_t' b_t).
-    { eapply rexec_dtrmt_in_fin; eauto. }
-    assert (INA : E_t' a_t) by tauto.
-    apply set_subset_union_r. left.
-    unfold WCore.reexec_thread. basic_solver. }
-  assert (INB : E_t b_t) by desf.
-  apply (WCore.rexec_acts GREEXEC) in INB.
-  destruct INB as [DB | [_ OK]]; basic_solver.
-Qed.
+Lemma dtrmt_in_E_s :
+  dtrmt_s ⊆₁ E_s.
+Proof using.
+Admitted.
 
-Lemma reexec_acts_s
-    (GREEXEC : WCore.reexec_gen X_t X_t' f_t dtrmt_t cmt_t thrdle) :
+Lemma reexec_acts_s :
   E_s ≡₁ dtrmt_s ∪₁ E_s ∩₁ tid ↓₁ WCore.reexec_thread X_s' dtrmt_s.
 Proof using INV INV' SIMREL RCFAT.
-  clear - INV INV' GREEXEC SIMREL RCFAT.
+  clear - INV INV' STEP SIMREL RCFAT.
   assert (NEQ : a_t <> b_t) by apply INV.
   assert (TID : tid a_t = tid b_t) by apply INV.
   enough (SUB : E_s \₁ dtrmt_s ⊆₁ tid ↓₁ WCore.reexec_thread X_s' dtrmt_s).
-  { split; [|
-      rewrite (dtrmt_in_E_s GREEXEC) at 1;
-        basic_solver].
+  { split; [| rewrite dtrmt_in_E_s at 1; basic_solver].
     rewrite set_union_minus
        with (s := E_s) (s' := dtrmt_s)
          at 1
          by eauto using dtrmt_in_E_s.
     rewrite <- SUB. basic_solver. }
-  arewrite (E_s \₁ dtrmt_s ⊆₁ E_s \₁ mapper ↑₁ (dtrmt_t \₁ extra_b)).
-  { unfold dtrmt_s. basic_solver. }
-  rewrite reexec_threads_s; eauto.
-  rewrite (rsr_acts SIMREL), set_minus_union_l.
-  rewrite set_map_union.
-  arewrite (
-    A_s \₁ (mapper ↑₁ (dtrmt_t \₁ extra_b)) ≡₁ A_s
-  ).
-  { unfold extra_a; desf; [| basic_solver].
-    split; [clear; basic_solver |].
-    unfolder. intros x XEQ. subst. split; auto.
-    unfold extra_b; intro FALSO; do 2 desf.
-    all: enough (E_t a_t) by eauto.
-    all: eapply rexec_dtrmt_in_start; eauto.
-    { erewrite <- (rsr_mapper_inv_bt y NEQ); eauto. }
-    erewrite <- rsr_mapper_inv_bt; eauto. }
-  apply set_subset_union_l.
-  split; eauto using reexec_acts_s_helper.
-  rewrite <- set_collect_minus;
-    [| eapply inj_dom_mori; eauto with xmm; red; auto with hahn].
-  rewrite <- reexec_thread_mapper; eauto.
-  rewrite set_minus_minus_r, set_collect_union.
-  apply set_subset_union_l. split.
-  { apply set_subset_union_r. left.
-    rewrite (WCore.rexec_acts GREEXEC). basic_solver. }
-  unfold extra_b. desf; [| basic_solver].
-  destruct classic with (E_t' a_t) as [INA | NINA].
-  { apply set_subset_union_r. left.
-    apply set_collect_mori; auto.
-    unfolder. ins. desf.
-    rewrite <- TID. unfold WCore.reexec_thread.
-    basic_solver. }
-  assert (INB' : E_t' b_t).
-  { eapply rexec_dtrmt_in_fin; eauto. desf. }
-  rewrite extra_a_some; auto.
-  assert (INB : E_t b_t).
-  { eapply rexec_dtrmt_in_start; eauto. desf. }
-  rewrite set_inter_absorb_l by basic_solver.
-  apply set_subset_union_r. right.
-  rewrite set_collect_eq, rsr_mapper_bt; auto.
-  basic_solver.
-Qed.
+Admitted.
 
-Lemma reexec_extra_a_ncmt
-    (GREEXEC : WCore.reexec_gen X_t X_t' f_t dtrmt_t cmt_t thrdle) :
-  extra_a X_t' a_t b_t b_t ⊆₁ set_compl cmt_s.
-Proof using INV.
-  clear - INV GREEXEC.
-  assert (NEQ : a_t <> b_t) by apply INV.
-  unfold extra_a, cmt_s. desf.
-  unfolder. ins. desf.
-  intros (y & CMT & MAP).
-  assert (YIN : E_t' y).
-  { now apply (WCore.reexec_embd_dom GREEXEC). }
-  enough (E_t' a_t) by desf.
-  erewrite <- (rsr_mapper_inv_bt _ NEQ); eauto.
-Qed.
-
-Lemma dtrmt_in_cmt
-    (GREEXEC : WCore.reexec_gen X_t X_t' f_t dtrmt_t cmt_t thrdle) :
+Lemma dtrmt_in_cmt :
   dtrmt_s ⊆₁ cmt_s.
-Proof using INV.
-  unfold dtrmt_s.
-  rewrite extra_d_cmt; eauto.
-  apply set_subset_union_l. split; auto with hahn.
-  unfold cmt_s.
-  apply set_collect_mori; auto.
-  transitivity dtrmt_t; [basic_solver |].
-  exact (WCore.dtrmt_cmt GREEXEC).
-Qed.
+Proof using INV STEP.
+Admitted.
 
 Lemma imm_sb_d_s_refl_helper x :
   ⦗eq x⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗eq x⦘ ⊆ ∅₂.
@@ -1075,162 +990,15 @@ Proof using INV INV'.
   auto.
 Qed.
 
-Lemma imm_sb_d_s
-    (GREEXEC : WCore.reexec_gen X_t X_t' f_t dtrmt_t cmt_t thrdle) :
+Lemma imm_sb_d_s :
   ⦗dtrmt_s⦘ ⨾ immediate (nin_sb G_s') ⨾ ⦗cmt_s⦘ ⊆
     ⦗dtrmt_s⦘ ⨾ immediate (nin_sb G_s') ⨾ ⦗dtrmt_s⦘.
-Proof using INV INV' LVAL NLOC ARW ARLX.
-  clear - INV INV' GREEXEC LVAL NLOC ARW ARLX.
-  assert (NB : ~is_init b_t) by apply INV.
-  assert (NEQ : a_t <> b_t) by apply INV.
-  assert (NEQ' : b_t <> a_t) by congruence.
-  rewrite rsr_sbE_imm
-     with (X_s := X_s') (X_t := X_t') (a_t := a_t) (b_t := b_t).
-  all: eauto using reexec_simrel.
-  rewrite !seq_union_l, !seq_union_r.
-  rewrite extra_sbE; eauto using reexec_simrel.
-  seq_rewrite <- cross_inter_l.
-  arewrite (dtrmt_s ∩₁ extra_a X_t' a_t b_t b_t ≡₁ ∅).
-  { split; [| auto with hahn].
-    rewrite reexec_extra_a_ncmt, dtrmt_in_cmt; eauto.
-    clear. basic_solver. }
-  apply union_mori; [| basic_solver].
-  destruct classic with (dtrmt_t a_t) as [AD | AND].
-  { assert (ACMT : cmt_t a_t).
-    { now apply (WCore.dtrmt_cmt GREEXEC). }
-    assert (AIN : E_t a_t).
-    { eapply rexec_dtrmt_in_start; eauto. }
-    assert (BIN : E_t b_t).
-    { now apply (rsr_at_bt_ord INV). }
-    assert (BDA : dtrmt_t b_t).
-    { eapply rexec_dtrmt_sb_dom; eauto.
-      exists a_t; unfolder. split; auto.
-      unfold sb; unfolder; splits; auto.
-      apply INV. }
-    assert (BCMT : cmt_t b_t).
-    { now apply (WCore.dtrmt_cmt GREEXEC). }
-    unfold cmt_s, dtrmt_s, extra_d, extra_b; desf; desf.
-    rewrite set_union_empty_r.
-    arewrite (dtrmt_t \₁ ∅ ≡₁ dtrmt_t) by basic_solver.
-    do 2 (rewrite rsr_setE_iff; eauto).
-    apply (WCore.dtrmt_sb_max GREEXEC). }
-  destruct classic with (cmt_t a_t) as [AC | NAC].
-  { assert (AIN : E_t' a_t).
-    { now apply (WCore.reexec_embd_dom GREEXEC). }
-    assert (BIN : E_t' b_t).
-    { now apply (rsr_at_bt_ord INV'). }
-    assert (SBA : immediate (nin_sb G_t') b_t a_t).
-    { unfold nin_sb.
-      enough (SB : immediate sb_t' b_t a_t).
-      { apply seq_eqv_imm. forward apply SB. basic_solver. }
-      apply (rsr_at_bt_imm INV'). basic_solver. }
-    assert (ND : ~dtrmt_t b_t).
-    { intro FALSO. apply AND.
-      eapply rexec_dtrmt_sbimm_codom; eauto.
-      exists b_t. forward apply SBA. basic_solver 11. }
-    unfold dtrmt_s, cmt_s, extra_b; desf; desf.
-    arewrite (dtrmt_t \₁ ∅ ≡₁ dtrmt_t) by basic_solver.
-    unfold extra_d; desf; [| rewrite set_union_empty_r].
-    { unfold a_s. desf.
-      rewrite rsr_setE_iff, rsr_setE_ex; eauto.
-      rewrite !id_union, !seq_union_l, !seq_union_r.
-      arewrite_false (⦗eq b_t⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗eq b_t⦘).
-      { apply imm_sb_d_s_refl_helper. }
-      arewrite_false (⦗eq b_t⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗cmt_t \₁ eq a_t⦘).
-      { sin_rewrite imm_sb_d_s_from_b_helper.
-        clear. basic_solver. }
-      rewrite !union_false_r. apply inclusion_union_r. left.
-      apply union_mori; [| reflexivity].
-      arewrite (
-        ⦗dtrmt_t⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗cmt_t \₁ eq a_t⦘ ≡
-        ⦗dtrmt_t⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗cmt_t⦘ ⨾ ⦗cmt_t \₁ eq a_t⦘
-      ).
-      { clear. basic_solver. }
-      sin_rewrite (WCore.dtrmt_sb_max GREEXEC).
-      clear. basic_solver. }
-    rewrite rsr_setE_iff; eauto.
-    destruct classic with (cmt_t b_t) as [BC|NBC].
-    { rewrite rsr_setE_iff; eauto.
-      apply (WCore.dtrmt_sb_max GREEXEC). }
-    assert (NBD :
-      ~ dom_rel (immediate (nin_sb G_t') ⨾ ⦗eq b_t⦘) ⊆₁ dtrmt_t
-    ) by tauto.
-    rewrite rsr_setE_ex, id_union, !seq_union_r; eauto.
-    arewrite (
-      ⦗dtrmt_t⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗cmt_t \₁ eq a_t⦘ ≡
-      ⦗dtrmt_t⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗cmt_t⦘ ⨾ ⦗cmt_t \₁ eq a_t⦘
-    ).
-    { clear. basic_solver. }
-    sin_rewrite (WCore.dtrmt_sb_max GREEXEC).
-    apply inclusion_union_l; [basic_solver |].
-    arewrite_false (⦗dtrmt_t⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗eq b_t⦘);
-      [| basic_solver].
-    enough (HH : dom_rel (⦗dtrmt_t⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗eq b_t⦘) ⊆₁ ∅).
-    { forward apply HH. clear. basic_solver 7. }
-    intros x1 (b' & HSET). apply NBD.
-    intros x2 (b'' & IMMSB).
-    assert (b' = b_t); desf.
-    { forward apply HSET. clear. basic_solver. }
-    assert (b'' = b_t); desf.
-    { forward apply IMMSB. clear. basic_solver. }
-    enough (EQ : x1 = x2).
-    { subst x1. forward apply HSET. basic_solver. }
-    eapply nin_sb_functional_l with (G := G_t').
-    { apply INV'. }
-    { forward apply HSET. clear. basic_solver. }
-    forward apply IMMSB. clear. basic_solver. }
-  destruct classic with (dtrmt_t b_t) as [DB|NDB].
-  { assert (BC : cmt_t b_t).
-    { now apply (WCore.dtrmt_cmt GREEXEC). }
-    unfold dtrmt_s, cmt_s, extra_b, extra_d.
-    desf; desf; rewrite set_union_empty_r.
-    { rewrite rsr_setE_iff; eauto; [| unfolder; tauto].
-      rewrite rsr_setE_niff; eauto.
-      rewrite id_union, !seq_union_r.
-      arewrite_false (⦗dtrmt_t \₁ eq b_t⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗eq a_t⦘).
-      { sin_rewrite imm_sb_d_s_to_a_helper.
-        clear. basic_solver. }
-      rewrite union_false_r.
-      arewrite (
-        ⦗dtrmt_t \₁ eq b_t⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗cmt_t \₁ eq b_t⦘ ≡
-        ⦗dtrmt_t \₁ eq b_t⦘ ⨾ ⦗dtrmt_t⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗cmt_t⦘ ⨾ ⦗cmt_t \₁ eq b_t⦘
-      ).
-      { clear. basic_solver. }
-      sin_rewrite (WCore.dtrmt_sb_max GREEXEC).
-      clear. basic_solver. }
-    exfalso. tauto. }
-  destruct classic with (cmt_t b_t) as [CB|NCB].
-  { unfold dtrmt_s, cmt_s, extra_b, extra_d.
-    desf; desf.
-    rewrite set_union_empty_r.
-    arewrite (dtrmt_t \₁ ∅ ≡₁ dtrmt_t) by basic_solver.
-    rewrite rsr_setE_iff; eauto.
-    rewrite rsr_setE_niff; eauto.
-    rewrite id_union, !seq_union_r.
-    arewrite_false (⦗dtrmt_t⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗eq a_t⦘).
-    { sin_rewrite imm_sb_d_s_to_a_helper.
-      clear - NDB. basic_solver. }
-    rewrite union_false_r.
-    arewrite (
-      ⦗dtrmt_t⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗cmt_t \₁ eq b_t⦘ ≡
-      ⦗dtrmt_t⦘ ⨾ immediate (nin_sb G_t') ⨾ ⦗cmt_t⦘ ⨾ ⦗cmt_t \₁ eq b_t⦘
-    ).
-    { clear. basic_solver. }
-    sin_rewrite (WCore.dtrmt_sb_max GREEXEC).
-    clear. basic_solver. }
-  unfold dtrmt_s, cmt_s, extra_b, extra_d.
-  desf; desf.
-  rewrite set_union_empty_r.
-  arewrite (dtrmt_t \₁ ∅ ≡₁ dtrmt_t) by basic_solver.
-  do 2 (rewrite rsr_setE_iff; eauto).
-  apply (WCore.dtrmt_sb_max GREEXEC).
-Qed.
-
-Hypothesis GREEXEC : WCore.reexec_gen X_t X_t' f_t dtrmt_t cmt_t thrdle.
+Proof using INV INV' STEP LVAL NLOC ARW ARLX.
+Admitted.
 
 Lemma reexec_step :
   WCore.reexec X_s X_s' f_s dtrmt_s cmt_s.
-Proof using INV INV' LVAL NLOC ARW ARLX RCFAT.
+Proof using INV INV' LVAL STEP NLOC ARW ARLX RCFAT.
   assert (NEQ : a_t <> b_t) by apply INV.
   assert (TEQ : tid a_t = tid b_t) by apply INV.
   assert (MEQA : mapper a_t = b_t).
@@ -1238,14 +1006,10 @@ Proof using INV INV' LVAL NLOC ARW ARLX RCFAT.
   assert (INJHELPER : inj_dom (codom_rel (⦗E_t' \₁ dtrmt_t⦘ ⨾ rf_t') ∪₁ dom_rel rhb_t'^?) mapper).
   { eapply inj_dom_mori; eauto with xmm.
     red. auto with hahn. }
-  assert (EXNCMT : A_s' ∩₁ cmt_s ≡₁ ∅).
-  { split; vauto.
-    rewrite (reexec_extra_a_ncmt GREEXEC).
-    clear. basic_solver. }
   assert (SURG :
     WCore.stable_uncmt_reads_gen X_s' cmt_s thrdle
   ).
-  { constructor; try now apply GREEXEC.
+  { constructor; try now apply STEP.
     admit. }
   assert (WF_START :
     WCore.wf (WCore.X_start X_s dtrmt_s) X_s' cmt_s
@@ -1257,135 +1021,27 @@ Proof using INV INV' LVAL NLOC ARW ARLX RCFAT.
   { admit. }
   { eapply dtrmt_in_cmt; eauto. }
   { unfold f_s, dtrmt_s.
-    apply fixset_union. split.
+    do 2 (try (apply fixset_union; split)).
     { rewrite Combinators.compose_assoc.
       apply fixset_swap.
       rewrite Combinators.compose_assoc,
               rsr_mapper_compose,
               Combinators.compose_id_right.
       all: auto.
-      eapply fixset_mori; auto; try now apply GREEXEC.
+      eapply fixset_mori; auto; try now apply STEP.
       clear. red. basic_solver. }
-    unfold extra_d. desf. unfold a_s.
-    unfolder. unfold compose. ins. desf.
-    rewrite (rsr_mapper_bt NEQ).
-    rewrite RCFAT; auto. }
+    { unfold extra_d. desf. unfold a_s.
+      unfolder. unfold compose. ins. desf.
+      rewrite (rsr_mapper_bt NEQ).
+      rewrite RCFAT; auto. }
+    admit. }
   { unfold cmt_s.
     admit. }
   { exact SURG. }
   { admit. (* sb-clos *) }
   { eapply imm_sb_d_s; eauto. }
   { admit. (* rpo edges *) }
-  { constructor.
-    { intros x' y'; unfold cmt_s, f_s.
-      intros [x [Hx]] [y [Hy]]; subst x' y'.
-      unfold compose.
-      change (mapper (mapper x)) with ((mapper ∘ mapper) x).
-      change (mapper (mapper y)) with ((mapper ∘ mapper) y).
-      rewrite !rsr_mapper_compose; auto; unfold id; intro EQf.
-      enough (EQxy: x = y); [by rewrite EQxy|].
-      apply (WCore.reexec_embd_inj (WCore.reexec_embd_corr GREEXEC)); auto.
-      apply (rsr_inj SIMREL).
-      { apply (WCore.reexec_embd_acts (WCore.reexec_embd_corr GREEXEC)); basic_solver. }
-      { apply (WCore.reexec_embd_acts (WCore.reexec_embd_corr GREEXEC)); basic_solver. }
-      done. }
-    { intros e CMT.
-      change (tid (f_s e)) with ((tid ∘ f_s) e).
-      unfold f_s.
-      rewrite <- !Combinators.compose_assoc.
-      change ((tid ∘ mapper ∘ f_t ∘ mapper) e)
-        with ((tid ∘ mapper) ((f_t ∘ mapper) e)).
-      unfold cmt_s in CMT. unfolder in CMT.
-      destruct CMT as (e' & CMT & EQ); subst e.
-      assert (INE : E_t ((f_t ∘ mapper) (mapper e'))).
-      { apply (WCore.reexec_embd_acts (WCore.reexec_embd_corr GREEXEC)).
-        unfolder. exists e'. split; auto.
-        change ((f_t ∘ mapper) (mapper e'))
-          with (f_t ((mapper ∘ mapper) e')).
-        rewrite rsr_mapper_compose; now unfold id. }
-      rewrite (rsr_tid SIMREL); auto.
-      unfold compose.
-      rewrite rsr_mapper_self_inv, rsr_mapper_tid'; auto.
-      now apply GREEXEC. }
-    { intros e CMT.
-      change (lab_s (f_s e)) with ((lab_s ∘ f_s) e).
-      unfold f_s.
-      rewrite <- !Combinators.compose_assoc.
-      unfold cmt_s in CMT. unfolder in CMT.
-      destruct CMT as (e' & CMT & EQ); subst e.
-      change ((lab_s ∘ mapper ∘ f_t ∘ mapper) (mapper e'))
-        with ((lab_s ∘ mapper) ((f_t ∘ (mapper ∘ mapper)) e')).
-      change (lab_s' (mapper e')) with ((lab_s' ∘ mapper) e').
-      rewrite rsr_mapper_compose, Combinators.compose_id_right; auto.
-      rewrite (rsr_lab SIMREL);
-        [| apply (WCore.reexec_embd_acts (WCore.reexec_embd_corr GREEXEC)); basic_solver].
-      rewrite (rsr_lab reexec_simrel);
-        [| apply (WCore.reexec_embd_dom GREEXEC); auto].
-      now apply GREEXEC. }
-    { admit. }
-    { rewrite (rsr_rf reexec_simrel),
-              restr_union, collect_rel_union.
-      arewrite_false (restr_rel cmt_s
-        (srf_s' ⨾ ⦗extra_a X_t' a_t b_t b_t ∩₁ R_s'⦘)).
-      { rewrite restr_relE, !seqA, <- id_inter.
-        rewrite (reexec_extra_a_ncmt GREEXEC).
-        clear. basic_solver. }
-      rewrite collect_rel_empty, union_false_r.
-      unfold cmt_s, f_s.
-      rewrite collect_rel_restr;
-        [| eapply inj_dom_mori; eauto with xmm;
-           unfold flip; basic_solver].
-      rewrite <- !collect_rel_compose.
-      rewrite Combinators.compose_assoc.
-      rewrite rsr_mapper_compose; auto.
-      rewrite Combinators.compose_assoc,
-              Combinators.compose_id_right.
-      rewrite collect_rel_compose.
-      rewrite (WCore.reexec_embd_rf (WCore.reexec_embd_corr GREEXEC)).
-      rewrite (rsr_rf SIMREL); auto with hahn. }
-    { rewrite (rsr_co reexec_simrel),
-              restr_union, collect_rel_union.
-      arewrite_false (restr_rel cmt_s
-        (add_max (extra_co_D E_s' lab_s' (loc_s' b_t))
-          (extra_a X_t' a_t b_t b_t ∩₁ W_s'))).
-      { rewrite restr_add_max. unfold add_max.
-        rewrite (reexec_extra_a_ncmt GREEXEC) at 2.
-        clear. basic_solver. }
-      rewrite collect_rel_empty, union_false_r.
-      unfold cmt_s, f_s.
-      rewrite collect_rel_restr;
-        [| eapply inj_dom_mori; eauto with xmm;
-           unfold flip; basic_solver].
-      rewrite <- !collect_rel_compose.
-      rewrite Combinators.compose_assoc.
-      rewrite rsr_mapper_compose; auto.
-      rewrite Combinators.compose_assoc,
-              Combinators.compose_id_right.
-      rewrite collect_rel_compose.
-      rewrite (WCore.reexec_embd_co (WCore.reexec_embd_corr GREEXEC)).
-      rewrite (rsr_co SIMREL); auto with hahn. }
-    { rewrite (rsr_rmw reexec_simrel).
-      unfold cmt_s, f_s.
-      rewrite collect_rel_restr;
-        [| eapply inj_dom_mori; eauto with xmm;
-           unfold flip; basic_solver].
-      rewrite <- !collect_rel_compose.
-      rewrite Combinators.compose_assoc.
-      rewrite rsr_mapper_compose; auto.
-      rewrite Combinators.compose_assoc,
-              Combinators.compose_id_right.
-      rewrite collect_rel_compose.
-      rewrite (WCore.reexec_embd_rmw (WCore.reexec_embd_corr GREEXEC)).
-      rewrite (rsr_rmw SIMREL); auto with hahn. }
-    unfold cmt_s, f_s.
-    rewrite <- !set_collect_compose.
-    rewrite Combinators.compose_assoc.
-    rewrite rsr_mapper_compose; auto.
-    rewrite Combinators.compose_assoc,
-            Combinators.compose_id_right.
-    rewrite set_collect_compose.
-    rewrite (WCore.reexec_embd_acts (WCore.reexec_embd_corr GREEXEC)).
-    rewrite (rsr_acts SIMREL); auto with hahn. }
+  { admit. }
   { apply (G_s_rfc INV' reexec_simrel). }
   { exact WF_START. (* wf start *) }
   { apply (rsr_cons INV' CONS reexec_simrel). }

--- a/src/reordering/ReorderingReexec.v
+++ b/src/reordering/ReorderingReexec.v
@@ -61,6 +61,9 @@ Notation "'rhb_t'" := (rhb G_t).
 Notation "'W_t'" := (fun x => is_true (is_w lab_t x)).
 Notation "'R_t'" := (fun x => is_true (is_r lab_t x)).
 Notation "'Loc_t_' l" := (fun e => loc_t e = l) (at level 1).
+Notation "'Acq_t'" := (fun e => is_true (is_acq lab_t e)).
+Notation "'Rel_t'" := (fun e => is_true (is_rel lab_t e)).
+Notation "'Rlx_t'" := (fun e => is_true (is_rlx lab_t e)).
 
 Notation "'lab_t''" := (lab G_t').
 Notation "'val_t''" := (val lab_t').
@@ -84,6 +87,9 @@ Notation "'R_t''" := (fun x => is_true (is_r lab_t' x)).
 Notation "'vf_t''" := (vf G_t').
 Notation "'vf_rhb_t''" := (vf_rhb G_t').
 Notation "'Loc_t_'' l" := (fun e => loc_t' e = l) (at level 1).
+Notation "'Acq_t''" := (fun e => is_true (is_acq lab_t' e)).
+Notation "'Rel_t''" := (fun e => is_true (is_rel lab_t' e)).
+Notation "'Rlx_t''" := (fun e => is_true (is_rlx lab_t' e)).
 
 Notation "'lab_s'" := (lab G_s).
 Notation "'val_s'" := (val lab_s).
@@ -212,22 +218,42 @@ Proof using INV'.
   now apply rsr_imm_Gs_wf.
 Qed.
 
-Hint Resolve rsr_rex_imm_wf : xmm.
-
 Lemma rsr_rex_imm_eqlab :
   eq_dom E_t' lab_t' (lab_s'' ∘ mapper).
 Proof using INV'.
-Admitted.
+  assert (NEQ : a_t <> b_t) by apply INV'.
+  simpl.
+  rewrite Combinators.compose_assoc.
+  rewrite rsr_mapper_compose, Combinators.compose_id_right; auto.
+  reflexivity.
+Qed.
+
+Hint Resolve rsr_rex_imm_wf rsr_rex_imm_eqlab : xmm.
 
 Lemma rsr_rex_imm_sbloc :
   sb_s'' ∩ same_loc_s'' ⊆ mapper ↑ (sb_t' ∩ same_loc_t').
 Proof using INV'.
-Admitted.
+  apply reord_sbloc' with (a := a_t) (b := b_t).
+  all: auto with xmm.
+  { apply INV'. }
+  apply (imm_G_s_sb INV').
+Qed.
 
 Lemma rsr_rex_imm_rpo :
   rpo_s'' ⊆ mapper ↑ rpo_t'.
 Proof using INV'.
-Admitted.
+  assert (NEQ : a_t <> b_t) by apply INV'.
+  apply reord_rpo_map' with (a := a_t) (b := b_t).
+  all: auto with xmm.
+  { eapply inj_dom_mori; auto with xmm.
+    red; auto with hahn. }
+  { apply (imm_G_s_sb INV'). }
+  { transitivity (set_compl (Rel_t' ∪₁ Acq_t'))
+      ; [apply INV' | basic_solver]. }
+  { transitivity (set_compl (Rel_t' ∪₁ Acq_t'))
+      ; [apply INV' | basic_solver]. }
+  all: rewrite set_unionC; apply INV'.
+Qed.
 
 Hint Resolve rsr_rex_imm_sbloc rsr_rex_imm_rpo
              rsr_rex_imm_eqlab : xmm.

--- a/src/reordering/ReorderingReexec.v
+++ b/src/reordering/ReorderingReexec.v
@@ -861,8 +861,7 @@ Proof using STEP INV' STEP.
   (* absorb rule works for the b_t *)
 Admitted.
 
-Lemma reexec_thread_mapper
-    (GREEXEC : WCore.reexec_gen X_t X_t' f_t dtrmt_t cmt_t thrdle) :
+Lemma reexec_thread_mapper :
   mapper ↑₁ (tid ↓₁ WCore.reexec_thread X_t' dtrmt_t) ≡₁
     tid ↓₁ WCore.reexec_thread X_t' dtrmt_t.
 Proof using INV INV'.
@@ -893,6 +892,60 @@ Proof using INV INV' SIMREL RCFAT.
          at 1
          by eauto using dtrmt_in_E_s.
     rewrite <- SUB. basic_solver. }
+  rewrite (rsr_acts SIMREL), set_minus_union_l.
+  arewrite (
+    mapper ↑₁ E_t \₁ (
+      mapper ↑₁ (dtrmt_t \₁ extra_b) ∪₁
+      extra_d ∪₁
+      exa_d
+    ) ⊆₁
+    mapper ↑₁ E_t \₁ (
+      mapper ↑₁ (dtrmt_t \₁ extra_b) ∪₁
+      extra_d
+    )
+  ).
+  { admit. }
+  arewrite (
+    A_s \₁ dtrmt_s ⊆₁
+      A_s \₁ exa_d
+  ).
+  { admit. }
+  apply set_subset_union_l. split.
+  { unfold dtrmt_s.
+    transitivity (
+      mapper ↑₁ E_t \₁ (mapper ↑₁ (dtrmt_t \₁ extra_b))
+    ); [basic_solver |].
+    rewrite set_collect_minus at 1
+      ; [| eapply inj_dom_mori; eauto with xmm].
+    all: unfold flip; auto with hahn.
+    rewrite set_minus_minus_r, reexec_threads_s.
+    apply set_subset_union_l. split.
+    { rewrite <- set_collect_minus
+      ; [| eapply inj_dom_mori; eauto with xmm].
+      all: unfold flip; auto with hahn.
+      rewrite <- reexec_thread_mapper.
+      apply set_collect_mori; auto.
+      admit. }
+    unfold extra_b; desf; [| basic_solver].
+    rewrite set_collect_eq, rsr_mapper_bt; auto.
+    unfold WCore.reexec_thread.
+    transitivity (eq a_t); [basic_solver |].
+    desf. basic_solver. }
+  unfold exa_d, a_s; desf.
+  { unfold extra_a; desf; [| basic_solver].
+    rewrite set_minusK. auto with hahn. }
+  rewrite set_minus_disjoint; [| basic_solver].
+  unfold extra_a; desf; auto with hahn.
+  assert (BIN : E_t b_t) by desf.
+  rewrite reexec_threads_s.
+  apply (WCore.rexec_acts STEP) in BIN.
+  destruct BIN as [BD | NBD]
+    ; [| forward apply NBD; desf; basic_solver].
+  assert (INA : E_t' a_t) by tauto.
+  assert (NDA : ~dtrmt_t a_t).
+  { intro FALSO. enough (E_t a_t) by tauto.
+    now apply (rexec_dtrmt_in_start STEP). }
+  unfold WCore.reexec_thread. basic_solver.
 Admitted.
 
 Lemma dtrmt_in_cmt :

--- a/src/reordering/ReorderingReexec.v
+++ b/src/reordering/ReorderingReexec.v
@@ -1002,6 +1002,22 @@ Admitted.
 Lemma rex_pfx :
   SubToFullExec.prefix (WCore.X_start X_s dtrmt_s) X_s'.
 Proof using INV INV' STEP LVAL NLOC ARW ARLX.
+  constructor; ins.
+  { rewrite set_inter_absorb_r; auto with xmm. }
+  { rewrite dtrmt_in_cmt, cmt_in_E_s.
+    change (mapper ↑₁ E_t' ∪₁ A_s') with E_s'.
+    basic_solver. }
+  { admit. }
+  { admit. }
+  { admit. (* FIXME: lab oddity *) }
+  { rewrite set_inter_absorb_r; auto with xmm.
+    change (
+      mapper ↑ rf_t' ∪
+      fake_srf (rsr_imm_g X_t' a_t b_t) b_t l_a ⨾ ⦗A_s' ∩₁ WCore.lab_is_r l_a⦘
+    ) with rf_s'.
+    rewrite <- restr_relE.
+    rewrite (rsr_rf SIMREL), (rsr_rf reexec_simrel).
+    admit. }
 Admitted.
 
 Lemma rsr_rex_restr_eq :

--- a/src/reordering/ReorderingReexec.v
+++ b/src/reordering/ReorderingReexec.v
@@ -1056,6 +1056,33 @@ Proof using SIMREL INV INV' LVAL STEP NLOC ARW ARLX RCFAT.
   apply (rexec_dtrmt_in_fin STEP); desf.
 Qed.
 
+Lemma rsr_sw_in_d :
+  sw_s' ≡ ⦗dtrmt_s⦘ ⨾ sw_s' ⨾ ⦗dtrmt_s⦘.
+Proof using SIMREL INV INV' LVAL STEP NLOC ARW ARLX RCFAT.
+  apply dom_helper_3.
+  assert (WF : Wf G_s').
+  { apply (new_G_s_wf INV' LVAL). }
+  rewrite (wf_swE WF).
+  assert (DIN : dtrmt_s ⊆₁ E_s').
+  { transitivity cmt_s; auto with xmm. }
+  rewrite set_union_minus
+     with (s := E_s') (s' := dtrmt_s)
+       at 1; auto.
+  rewrite id_union, seq_union_l.
+  arewrite_false (⦗E_s' \₁ dtrmt_s⦘ ⨾ sw_s').
+  { rewrite (wf_swD WF), rsr_rex_ndtrmt_rlx.
+    clear. basic_solver. }
+  rewrite seq_false_l, union_false_l.
+  rewrite set_union_minus
+     with (s := E_s') (s' := dtrmt_s)
+       at 1; auto.
+  rewrite id_union, seq_union_r.
+  arewrite_false (sw_s' ⨾ ⦗E_s' \₁ dtrmt_s⦘).
+  { rewrite (wf_swD WF), rsr_rex_ndtrmt_rlx.
+    clear. basic_solver. }
+  rewrite union_false_l. basic_solver.
+Qed.
+
 Lemma rsr_rex_crfc_helper
     (DB : dtrmt_t b_t)
     (NINA : ~E_t' a_t) :

--- a/src/reordering/ReorderingReexec.v
+++ b/src/reordering/ReorderingReexec.v
@@ -339,11 +339,10 @@ Proof using INV' LVAL NLOC ARW ARLX.
     rewrite seq_union_l, !seqA.
     apply union_mori; [basic_solver |].
     rewrite rsr_rex_rf_helper.
-    rewrite srf_as_rhb.
-    (* rewrite srf_in_vf_sb, id_inter.
-    rewrite seqA. sin_rewrite SUBHELP.
-    basic_solver 11. *)
-    admit. }
+    rewrite srf_as_rhb, srf_rhb_vf_rhb_sb,
+            !seqA, id_inter.
+    sin_rewrite SUBHELP.
+    rewrite !seqA. clear. basic_solver 11. }
   apply inclusion_union_r. right.
   rewrite !seqA.
   unfold rhb. rewrite ct_end.
@@ -376,21 +375,6 @@ Proof using INV' LVAL NLOC ARW ARLX.
   rewrite <- seq_union_r.
   rewrite rpo_in_sb.
   clear. basic_solver 11.
-Admitted.
-
-Lemma rsr_rex_vfexa :
-  vf_s' ⨾ ⦗A_s'⦘ ≡
-    ⦗A_s' ∩₁ W_s'⦘ ∪
-      vf_s' ⨾ ⦗E_s' \₁ A_s'⦘ ⨾ sb_s' ⨾ ⦗A_s'⦘.
-Proof using INV' LVAL NLOC ARW ARLX.
-  split; [apply rsr_rex_vfexa' |].
-  apply inclusion_union_l.
-  { unfold vf. clear. rewrite 2!crE. simpl.
-    clear. basic_solver 11. }
-  transitivity (
-    vf_s' ⨾ sb_s' ⨾ ⦗A_s'⦘
-  ); [| now sin_rewrite vf_sb_in_vf].
-  clear. basic_solver.
 Qed.
 
 Definition extra_b :=

--- a/src/reordering/ReorderingReexec.v
+++ b/src/reordering/ReorderingReexec.v
@@ -318,7 +318,7 @@ Proof using INV' LVAL NLOC ARW ARLX.
 Qed.
 
 Lemma rsr_rex_vfexa' :
-  vf_s' ⨾ ⦗A_s'⦘ ⊆ ⦗A_s' ∩₁ W_s'⦘ ∪ vf_s' ⨾ ⦗E_s' \₁ A_s'⦘ ⨾ sb_s' ⨾ ⦗A_s'⦘.
+  vf_rhb_s' ⨾ ⦗A_s'⦘ ⊆ ⦗A_s' ∩₁ W_s'⦘ ∪ vf_rhb_s' ⨾ ⦗E_s' \₁ A_s'⦘ ⨾ sb_s' ⨾ ⦗A_s'⦘.
 Proof using INV' LVAL NLOC ARW ARLX.
   clear STEP RCFAT RCFBT.
   clear f_t cmt_t X_t X_s SIMREL INV.
@@ -330,8 +330,8 @@ Proof using INV' LVAL NLOC ARW ARLX.
     rewrite wf_sbE at 1. rewrite !seqA.
     unfolder. ins. desf. splits; auto.
     intro FALSO. desf. eapply sb_irr; eauto. }
-  unfold vf at 1.
-  rewrite crE with (r := hb_s').
+  unfold vf_rhb at 1.
+  rewrite crE with (r := rhb_s').
   rewrite !seq_union_r, seq_id_r.
   rewrite seq_union_l. apply inclusion_union_l.
   { rewrite crE.
@@ -339,23 +339,44 @@ Proof using INV' LVAL NLOC ARW ARLX.
     rewrite seq_union_l, !seqA.
     apply union_mori; [basic_solver |].
     rewrite rsr_rex_rf_helper.
-    rewrite srf_in_vf_sb, id_inter.
+    rewrite srf_as_rhb.
+    (* rewrite srf_in_vf_sb, id_inter.
     rewrite seqA. sin_rewrite SUBHELP.
-    basic_solver 11. }
+    basic_solver 11. *)
+    admit. }
   apply inclusion_union_r. right.
   rewrite !seqA.
-  unfold hb. rewrite ct_end.
+  unfold rhb. rewrite ct_end.
   rewrite <- cr_of_ct.
-  change ((sb_s' ∪ sw_s')⁺) with hb_s'.
+  change ((sb_s' ∩ same_loc_s' ∪ rpo_s' ∪ sw_s')⁺) with rhb_s'.
   rewrite !seqA.
-  arewrite (⦗E_s'⦘ ⨾ ⦗W_s'⦘ ⨾ rf_s'^? ⨾ hb_s'^? ≡ vf_s').
-  rewrite seq_union_l. rewrite SUBHELP at 1.
-  arewrite_false (sw_s' ⨾ ⦗A_s'⦘);
-    [| now rewrite union_false_r].
-  rewrite (wf_swD (new_G_s_wf INV' LVAL)).
-  rewrite (rsr_rex_a_rlx l_a INV' ARLX).
-  clear. basic_solver.
-Qed.
+  arewrite (⦗E_s'⦘ ⨾ ⦗W_s'⦘ ⨾ rf_s'^? ⨾ rhb_s'^? ≡ vf_rhb_s').
+  rewrite !seq_union_l.
+  arewrite_false (sw_s' ⨾ ⦗A_s'⦘).
+  { rewrite (wf_swD (new_G_s_wf INV' LVAL)).
+    rewrite (rsr_rex_a_rlx l_a INV' ARLX).
+    clear. basic_solver. }
+  arewrite (
+    sb_s' ∩ same_loc_s' ⨾ ⦗A_s'⦘ ⊆
+      ⦗E_s' \₁ A_s'⦘ ⨾ sb_s' ∩ same_loc_s' ⨾ ⦗A_s'⦘).
+  { rewrite <- seq_eqv_inter_lr, <- seq_eqv_inter_ll.
+    now rewrite SUBHELP at 1. }
+  arewrite (
+    rpo_s' ⨾ ⦗A_s'⦘ ⊆
+      ⦗E_s' \₁ A_s'⦘ ⨾ rpo_s' ⨾ ⦗A_s'⦘
+  ).
+  { remember (E_s' \₁ A_s') as NA.
+    unfolder. intros x y (RPO & NEXA).
+    splits; auto. subst NA.
+    apply rpo_in_sb in RPO.
+    forward apply (SUBHELP x y)
+      ; [basic_solver |].
+    clear - RPO NEXA. basic_solver. }
+  rewrite union_false_r.
+  rewrite <- seq_union_r.
+  rewrite rpo_in_sb.
+  clear. basic_solver 11.
+Admitted.
 
 Lemma rsr_rex_vfexa :
   vf_s' ⨾ ⦗A_s'⦘ ≡

--- a/src/xmm/Thrdle.v
+++ b/src/xmm/Thrdle.v
@@ -5,7 +5,7 @@ From imm Require Import Events Execution.
 Require Import Setoid Morphisms.
 
 Require Import xmm_s xmm_s_hb.
-Require Import Core AuxDef Rhb.
+Require Import Core AuxDef Rhb Srf.
 
 Open Scope program_scope.
 
@@ -23,6 +23,9 @@ Notation "'sb'" := (sb G).
 Notation "'rf'" := (rf G).
 Notation "'hb'" := (hb G).
 Notation "'rhb'" := (rhb G).
+Notation "'vf'" := (vf G).
+Notation "'vf_rhb'" := (vf_rhb G).
+Notation "'Tid_' t" := (fun x => tid x = t) (at level 1).
 
 Lemma thrdle_sb_closed
   (INIT_MIN : min_elt thrdle tid_init)
@@ -63,25 +66,31 @@ Proof using.
   basic_solver 11.
 Qed.
 
-Lemma thrdle_with_rhb
+Lemma thrdle_with_rhb cmt
     (INIT_MIN : min_elt thrdle tid_init)
-    (INIT_LEAST : least_elt thrdle tid_init) :
-  ⦗E \₁ dtrmt⦘ ⨾ rf ⨾ hb^? ⊆ sb ∪ tid ↓ thrdle <->
-    ⦗E \₁ dtrmt⦘ ⨾ rf ⨾ rhb^? ⊆ sb ∪ tid ↓ thrdle.
+    (INIT_LEAST : least_elt thrdle tid_init)
+    (WF : Wf G)
+    (TID : E ∩₁ Tid_ tid_init ⊆₁ is_init) :
+  vf ⨾ same_tid ⨾ ⦗E \₁ cmt⦘ ⊆ tid ↓ thrdle ∪ same_tid <->
+    vf_rhb ⨾ same_tid ⨾ ⦗E \₁ cmt⦘ ⊆ tid ↓ thrdle ∪ same_tid.
 Proof using.
   split; intros SUB.
-  { now rewrite rhb_in_hb. }
-  rewrite hb_helper.
-  rewrite cr_union_r, !seq_union_r.
-  apply inclusion_union_l; auto.
-  assert (SUB' : ⦗E \₁ dtrmt⦘ ⨾ rf ⊆ sb ∪ tid ↓ thrdle).
-  { rewrite <- SUB. basic_solver. }
-  rewrite <- seqA, SUB', seq_union_l.
-  apply inclusion_union_l.
-  { rewrite rewrite_trans.
-    all: auto using sb_trans with hahn. }
-  rewrite <- thrdle_sb_closed at 2; auto.
-  basic_solver 11.
+  { now rewrite vfrhb_in_vf. }
+  seq_rewrite (vf_tid_as_rhb WF).
+  rewrite seq_union_l, !seqA, SUB.
+  apply inclusion_union_l; [reflexivity |].
+  apply inclusion_union_r. left.
+  unfolder. intros x y (XINIT & (z & SB & TEQ & CMT)).
+  destruct x as [xl | xt xn]; ins.
+  apply INIT_LEAST. intro TEQ'.
+  assert (ZNINI : ~is_init z).
+  { apply no_sb_to_init in SB.
+    forward apply SB. basic_solver. }
+  assert (YNINI : ~is_init y).
+  { intro FALSO. apply ZNINI, TID.
+    split; [forward apply SB; unfold sb; basic_solver |].
+    now rewrite TEQ. }
+  apply YNINI, TID. basic_solver.
 Qed.
 
 End Thrdle.


### PR DESCRIPTION
The way the re-execution step is done in reordering at the moment is far from "good enough" as it has several corner cases that are not handled. This PR provides an alternative formalisation that handles all the known corner cases, leaving much less tough looking admits.

All admits are listed in `TRACKIND.md`